### PR TITLE
Update help to mention that URL is allowed as input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ struct Opt {
         name = "gtfs",
         short = "i",
         long = "input",
-        help = "Path to the gtfs file. Can be a directory or a zip file",
+        help = "Path to the GTFS file (can be a directory or a zip file) or URL to an online GTFS file",
         parse(from_os_str)
     )]
     file: PathBuf,


### PR DESCRIPTION
While doing some testing, I have noticed that an URL can be passed as `--input`.

This is a behaviour allowed by the [gtfs-structures dependency](https://github.com/rust-transit/gtfs-structure#feature-read-url).

In this PR I am updating the CLI help to reflect that.

