### PR TITLE
Bump gtfs-structures to 0.32.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["data-structures"]
 
 [dependencies]
 
-gtfs-structures = "0.32"
+gtfs-structures = "0.32.2"
 geojson = "0.22"
 clap = { version = "3", features = ["derive"] }
 geo-types = "0.7"


### PR DESCRIPTION
To benefit from https://github.com/rust-transit/gtfs-structure/commit/2b342876bd82f04b407ad1f6d71516566e4995cb